### PR TITLE
Add PyPI description and keywords for discoverability

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Extend Python Library
 
-Official Python SDK for [Extend](https://www.extend.ai) (extend.ai) — the document processing API. Parse, extract, classify, split, and edit PDFs and 30+ file types via PyPI (`extend-ai`).
+Official Python SDK for [Extend](https://www.extend.ai) (extend.ai) — the document processing API. Parse, extract, classify, split, and edit PDFs and 35+ file types via PyPI (`extend-ai`).
 
 [![PyPI version](https://img.shields.io/pypi/v/extend-ai.svg)](https://pypi.python.org/pypi/extend-ai)
 [![Python versions](https://img.shields.io/pypi/pyversions/extend-ai.svg)](https://pypi.python.org/pypi/extend-ai)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Extend Python Library
 
+Official Python SDK for [Extend](https://www.extend.ai) (extend.ai) — the document processing API. Parse, extract, classify, split, and edit PDFs and 30+ file types via PyPI (`extend-ai`).
+
 [![PyPI version](https://img.shields.io/pypi/v/extend-ai.svg)](https://pypi.python.org/pypi/extend-ai)
 [![Python versions](https://img.shields.io/pypi/pyversions/extend-ai.svg)](https://pypi.python.org/pypi/extend-ai)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ dynamic = ["version"]
 [tool.poetry]
 name = "extend_ai"
 version = "1.17.0"
-description = "Official Python SDK for Extend (extend.ai) — the document processing API. Parse, extract, classify, split, and edit PDFs and 30+ file types"
+description = "Official Python SDK for Extend (extend.ai) — the document processing API. Parse, extract, classify, split, and edit PDFs and 35+ file types"
 readme = "README.md"
 authors = []
 keywords = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,10 +5,19 @@ dynamic = ["version"]
 [tool.poetry]
 name = "extend_ai"
 version = "1.17.0"
-description = ""
+description = "Official Python SDK for Extend (extend.ai) — the document processing API. Parse, extract, classify, split, and edit PDFs and 30+ file types"
 readme = "README.md"
 authors = []
-keywords = []
+keywords = [
+    "extend",
+    "document processing",
+    "ocr",
+    "pdf parsing",
+    "data extraction",
+    "document ai",
+    "idp",
+    "extend.ai",
+]
 license = "MIT"
 classifiers = [
     "Intended Audience :: Developers",


### PR DESCRIPTION
## Summary
- Fill empty `description` and `keywords` in `pyproject.toml` so PyPI (Python Package Index) surfaces searchable prose about Extend document processing
- Add a plain-English blurb before the README badges

## Test plan
- [ ] Confirm `pyproject.toml` description/keywords look correct
- [ ] After publish, verify the PyPI (Python Package Index) package page shows the new description
- [ ] Pair with the documentation Fern generators PR so the next regen preserves `package-description`